### PR TITLE
Load env vars directly from init and add ssl exception to errors list

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import os
 import sys
 import traceback
 
@@ -9,12 +8,13 @@ import aiohttp
 import discord
 from discord.ext import commands
 from discord.ext.commands import ExtensionFailed, ExtensionNotFound, NoEntryPointError
-from dotenv import load_dotenv
 
 from utils import locale_v2
+from utils.valorant import (
+    TOKEN,
+    OWNER_ID
+)
 from utils.valorant.cache import get_cache
-
-load_dotenv()
 
 initial_extensions = [
     'cogs.admin',
@@ -64,7 +64,7 @@ class ValorantBot(commands.Bot):
             self.session = aiohttp.ClientSession()
         
         try:
-            self.owner_id = int(os.getenv('OWNER_ID'))
+            self.owner_id = int(OWNER_ID)
         except ValueError:
             self.bot_app_info = await self.application_info()
             self.owner_id = self.bot_app_info.owner.id
@@ -97,7 +97,7 @@ class ValorantBot(commands.Bot):
     
     async def start(self, debug: bool = False) -> None:
         self.debug = debug
-        return await super().start(os.getenv('TOKEN'), reconnect=True)
+        return await super().start(TOKEN, reconnect=True)
 
 
 def run_bot() -> None:

--- a/cogs/errors.py
+++ b/cogs/errors.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from ssl import SSLCertVerificationError
 
 import traceback
 from typing import TYPE_CHECKING, Union
@@ -36,7 +37,7 @@ class ErrorHandler(commands.Cog):
             error = "You are not the owner of this bot."
         elif isinstance(error, BadArgument):
             error = "Bad argument."
-        elif isinstance(error, (ValorantBotError, ResponseError, HandshakeError, DatabaseError, AuthenticationError)):
+        elif isinstance(error, (ValorantBotError, ResponseError, HandshakeError, DatabaseError, AuthenticationError, SSLCertVerificationError)):
             error = error
         elif isinstance(error, ResponseError):
             error = "Empty response from Riot server."

--- a/utils/valorant/__init__.py
+++ b/utils/valorant/__init__.py
@@ -1,0 +1,26 @@
+import logging
+import os
+
+from dotenv import load_dotenv, find_dotenv
+
+# enable logging (useful in future)
+logging.basicConfig(
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    level=logging.INFO,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+ENV = bool(os.path.exists(find_dotenv()))
+
+load_dotenv(find_dotenv())
+
+if ENV:
+    TOKEN = os.environ.get("TOKEN", None)
+    try:
+        OWNER_ID = int(os.environ.get("OWNER_ID", None))
+    except ValueError:
+        raise Exception("Your OWNER_ID env variable is not a valid integer.")
+
+else:
+    LOGGER.info(".env file missing!")


### PR DESCRIPTION
- logging in console enabled for detailed traceback if needed
- variables in .env are directly loaded from init as global variables
- SSLCertVerificationError added to errors list as many users were having that problem