### PR TITLE
German

### DIFF
--- a/languages/_guide.txt
+++ b/languages/_guide.txt
@@ -6,6 +6,7 @@
 'zh-CN' chinese / translate by JL Lai#5533
 'pt-BR' Brazilian Portuguese / translate by sev#1337
 'ja' japanese /  translate by KANATA IS GOD#6356
+'de' german / translate by Hackante#1482
 
 Look up the language code for your language in https://discord.com/developers/docs/reference#locales
 

--- a/languages/de.json
+++ b/languages/de.json
@@ -18,18 +18,18 @@
         "FAILED": "Abmelden fehlgeschlagen, bitte versuche es erneut!"
       },
       "store": {
-        "NAME": "store",
-        "DESCRIPTION": "Shows your daily store in your accounts",
+        "NAME": "shop",
+        "DESCRIPTION": "Zeigt dir den Shop deines Kontos an",
         "DESCRIBE": {
-          "username": "Input username! (temporary login)",
-          "password": "Input password! (temporary login)"
+          "username": "Benutzername eingeben! (temporäre Anmeldung)",
+          "password": "Passwort eingeben! (temporäre Anmeldung)"
         },
-        "RESPONSE": "Daily store for **{username}** \nResets {duration}"
+        "RESPONSE": "Täglicher Shop für **{username}** \nZurücksetzen {duration}"
       },
       "point": {
-        "NAME": "point",
-        "DESCRIPTION": "View your remaining Valorant and Radiant Points (VP/RP)",
-        "POINT": "Points"
+        "NAME": "punkte",
+        "DESCRIPTION": "Sieh deine verbleibenden Valorant und Radiant Punkte (VP/RP) an",
+        "POINT": "Punkte"
       },
       "mission": {
         "NAME": "mission",

--- a/languages/de.json
+++ b/languages/de.json
@@ -33,7 +33,7 @@
       },
       "mission": {
         "NAME": "mission",
-        "DESCRIPTION": "Zeigt deinen täglichen/wöchentlichen Missionsfortschritt an",
+        "DESCRIPTION": "Zeigt deinen täglichen/wöchentlichen Missions-Fortschritt an",
         "TITLE": "Mission",
         "DAILY": "Täglich",
         "WEEKLY": "Wöchentlich",
@@ -64,7 +64,7 @@
         "NAME": "hinzufügen",
         "DESCRIPTION": "Füge eine Benachrichtigung hinzu, wenn ein bestimmter Skin im Shop verfügbar ist",
         "DESCRIBE": {
-          "skin": "Skinname bei dem du benachrichtigt werden willst"
+          "skin": "Skin-Name bei dem du benachrichtigt werden willst"
         },
         "SUCCESS": "Benachrichtigung für {emoji} **{skin}** erfolgreich hinzugefügt",
         "SKIN_ALREADY_IN_LIST": "{emoji} **{skin}** ist bereits in deinen Benachrichtigungen",
@@ -75,26 +75,26 @@
       "notify_list": {
         "NAME": "liste",
         "DESCRIPTION": "Zeigt die Skins, für die du Benachrichtigungen erhälst",
-        "TITLE": "Deine Benachrichtigungsliste",
+        "TITLE": "Deine Benachrichtigungs-Liste",
         "DONT_HAVE_NOTIFY": "Du hast keine Benachrichtigungen",
         "REMOVE_NOTIFY": "Auf den Knopf klicken um  Benachrichtigung zu entfernen"
       },
       "notify_mode": {
         "NAME": "modus",
-        "DESCRIPTION": "Ändere den Benachrichtigungsmodus",
+        "DESCRIPTION": "Ändere den Benachrichtigungs-Modus",
         "DESCRIBE": {
-          "mode": "Der neue Benachrichtigungsmodus"
+          "mode": "Der neue Benachrichtigungs-Modus"
         },
-        "SUCCESS": "Benarichtigingsmodus erfolgreich zu **{mode}** geändert",
-        "TURN_OFF": "Benachrichtigungsmodus ausschalten"
+        "SUCCESS": "Benachrichtigungs-Modus erfolgreich zu **{mode}** geändert",
+        "TURN_OFF": "Benachrichtigungs-Modus ausschalten"
       },
       "notify_test": {
         "NAME": "test",
         "DESCRIPTION": "Benachrichtigung testen",
         "NOTIFY_IS_WORKING": "Benachrichtigung funktioniert",
         "NOTIFY_TURN_OFF": "Du hast die Benachrichtigungen ausgeschaltet",
-        "EMPTY_LIST": "Benachrichtigungsliste ist leer",
-        "BOT_MISSING_PERM": "**Ich besitze keine Berechtigungen Benachrichtigungen in diesen Kanal zu senden!** \nBitte überprüfe ob der Bot diese Berechtigungen in diesem Kanal hat: `Kanal anzeigen`, `Nachrichten senden`, `Links einbetten`, `Externe Emojis verwenden`. Versuche `/notify test` danach.",
+        "EMPTY_LIST": "Benachrichtigungs-Liste ist leer",
+        "BOT_MISSING_PERM": "**Ich besitze keine Berechtigungen, Benachrichtigungen in diesen Kanal zu senden!** \nBitte überprüfe ob der Bot diese Berechtigungen in diesem Kanal hat: `Kanal anzeigen`, `Nachrichten senden`, `Links einbetten`, `Externe Emojis verwenden`. Versuche `/notify test` danach.",
         "FAILED_SEND_NOTIFY": "Fehler beim senden der Benachrichtigung, bitte versuche es erneut",
         "PLEASE_ALLOW_DM_MESSAGE": "Bitte lasse Direktnachrichten in deinen Privatsphäreeinstellungen zu."
       },
@@ -104,11 +104,11 @@
       },
       "notify_channel": {
         "NAME": "kanal",
-        "DESCRIPTION": "Ändere den Benachrichtigungskanal",
+        "DESCRIPTION": "Ändere den Benachrichtigungs-Kanal",
         "DESCRIBE": {
-          "channel": "Select the channel you want to change."
+          "channel": "Wähle den Kanal zum Ändern aus"
         },
-        "SUCCESS": "Benachrichtigungskanal zu **{channel}** geändert"
+        "SUCCESS": "Benachrichtigungs-Kanal zu **{channel}** geändert"
       },
       "bundle": {
         "NAME": "Paket",

--- a/languages/de.json
+++ b/languages/de.json
@@ -28,7 +28,7 @@
       },
       "point": {
         "NAME": "punkte",
-        "DESCRIPTION": "Sieh deine verbleibenden Valorant und Radiant Punkte (VP/RP) an",
+        "DESCRIPTION": "Sieh dir deine verbleibenden Valorant und Radiant Punkte (VP/RP) an",
         "POINT": "Punkte"
       },
       "mission": {

--- a/languages/de.json
+++ b/languages/de.json
@@ -24,7 +24,7 @@
           "username": "Benutzername eingeben! (temporäre Anmeldung)",
           "password": "Passwort eingeben! (temporäre Anmeldung)"
         },
-        "RESPONSE": "Täglicher Shop für **{username}** \nZurücksetzen {duration}"
+        "RESPONSE": "Täglicher Shop für **{username}** \nZurückgesetzt {duration}"
       },
       "point": {
         "NAME": "punkte",
@@ -33,151 +33,151 @@
       },
       "mission": {
         "NAME": "mission",
-        "DESCRIPTION": "View your daily/weekly mission progress",
+        "DESCRIPTION": "Zeigt deinen täglichen/wöchentlichen Missionsfortschritt an",
         "TITLE": "Mission",
-        "DAILY": "Daily",
-        "WEEKLY": "Weekly",
-        "NEWPLAYER": "New Player",
-        "NO_MISSION": "No missions available",
-        "DAILY_RESET": "Resets {duration}",
-        "REFILLS": "Refills {duration}"
+        "DAILY": "Täglich",
+        "WEEKLY": "Wöchentlich",
+        "NEWPLAYER": "Neuer Spieler",
+        "NO_MISSION": "Keine Missionen",
+        "DAILY_RESET": "Zurückgesetzt {duration}",
+        "REFILLS": "Aufgefüllt {duration}"
       },
       "nightmarket": {
-        "NAME": "nightmarket",
-        "DESCRIPTION": "Show skin offers on the nightmarket",
-        "RESPONSE": "NightMarket for **{username}** | Expires {duration}",
-        "NIGMARKET_HAS_END": "**NightMarket** has been ended"
+        "NAME": "nachtmarkt",
+        "DESCRIPTION": "Zeigt Skinangebote auf dem Nachtmarkt an",
+        "RESPONSE": "Nachtmarkt für **{username}** | Läuft {duration} ab",
+        "NIGMARKET_HAS_END": "**Nachtmarkt** ist vorbei"
       },
       "battlepass": {
         "NAME": "battlepass",
-        "DESCRIPTION": "View your battlepass current tier",
-        "RESPONSE": "**Next Reward:** {next}\n**Type:** {type}\n**XP:** {xp}\n**ACT END:** {end}",
-        "TIER": "TIER",
-        "PLAYER_CARD": "Player Card",
-        "SPRAY": "Spray",
-        "BUDDY": "Buddie",
-        "POINT": "Point",
-        "PLAYER_TITLE": "Title",
+        "DESCRIPTION": "Zeigt deine momentane Battlepass-Stufe an",
+        "RESPONSE": "**Nächste Belohnung:** {next}\n**Typ:** {type}\n**XP:** {xp}\n**AKT ENDE:** {end}",
+        "TIER": "Stufe",
+        "PLAYER_CARD": "Spieler Banner",
+        "SPRAY": "Graffiti",
+        "BUDDY": "Talismane",
+        "POINT": "Punkt",
+        "PLAYER_TITLE": "Titel",
         "SKIN": "Skin"
       },
       "notify_add": {
-        "NAME": "add",
-        "DESCRIPTION": "Set a notification when a specific skin is available on your store",
+        "NAME": "hinzufügen",
+        "DESCRIPTION": "Füge eine Benachrichtigung hinzu, wenn ein bestimmter Skin im Shop verfügbar ist",
         "DESCRIBE": {
-          "skin": "The name of the skin you want to notify"
+          "skin": "Skinname bei dem du benachrichtigt werden willst"
         },
-        "SUCCESS": "Successfully set an notify for the {emoji} **{skin}**",
-        "SKIN_ALREADY_IN_LIST": "{emoji} **{skin}** is already added to your notification list",
-        "NOT_FOUND": "Skin is not found",
-        "REMOVE_NOTIFY": "Remove Notify",
-        "REMOVED_NOTIFY": "**{skin}** has been removed from notify"
+        "SUCCESS": "Benachrichtigung für {emoji} **{skin}** erfolgreich hinzugefügt",
+        "SKIN_ALREADY_IN_LIST": "{emoji} **{skin}** ist bereits in deinen Benachrichtigungen",
+        "NOT_FOUND": "Skin nicht gefunden",
+        "REMOVE_NOTIFY": "Entferne Benachrichtigung",
+        "REMOVED_NOTIFY": "**{skin}** wurde von deinen Benachrichtigungen entfernt"
       },
       "notify_list": {
-        "NAME": "list",
-        "DESCRIPTION": "View skins you have set a notification for.",
-        "TITLE": "Your Notify List",
-        "DONT_HAVE_NOTIFY": "You don't have any notifications",
-        "REMOVE_NOTIFY": "Click button to remove from notify list"
+        "NAME": "liste",
+        "DESCRIPTION": "Zeigt die Skins, für die du Benachrichtigungen erhälst",
+        "TITLE": "Deine Benachrichtigungsliste",
+        "DONT_HAVE_NOTIFY": "Du hast keine Benachrichtigungen",
+        "REMOVE_NOTIFY": "Auf den Knopf klicken um  Benachrichtigung zu entfernen"
       },
       "notify_mode": {
-        "NAME": "mode",
-        "DESCRIPTION": "Change notification mode",
+        "NAME": "modus",
+        "DESCRIPTION": "Ändere den Benachrichtigungsmodus",
         "DESCRIBE": {
-          "mode": "The mode you want to change to"
+          "mode": "Der neue Benachrichtigungsmodus"
         },
-        "SUCCESS": "Successfully changed your notification mode to **{mode}**",
-        "TURN_OFF": "Turn off notification mode"
+        "SUCCESS": "Benarichtigingsmodus erfolgreich zu **{mode}** geändert",
+        "TURN_OFF": "Benachrichtigungsmodus ausschalten"
       },
       "notify_test": {
         "NAME": "test",
-        "DESCRIPTION": "Testing notification",
-        "NOTIFY_IS_WORKING": "Notification is working",
-        "NOTIFY_TURN_OFF": "You've not turned on notification mode",
-        "EMPTY_LIST": "Notify list is empty",
-        "BOT_MISSING_PERM": "**I don't have permission to send notifications in this channel!** \nplease check permission the bot can `View channel`, `Send messages`, `Embed links` and `Use external emoji`. in this channel, then try `/notify test`.",
-        "FAILED_SEND_NOTIFY": "Failed to send notification, please try again",
-        "PLEASE_ALLOW_DM_MESSAGE": "Please allow DM message in your privacy settings"
+        "DESCRIPTION": "Benachrichtigung testen",
+        "NOTIFY_IS_WORKING": "Benachrichtigung funktioniert",
+        "NOTIFY_TURN_OFF": "Du hast die Benachrichtigungen ausgeschaltet",
+        "EMPTY_LIST": "Benachrichtigungsliste ist leer",
+        "BOT_MISSING_PERM": "**Ich besitze keine Berechtigungen Benachrichtigungen in diesen Kanal zu senden!** \nBitte überprüfe ob der Bot diese Berechtigungen in diesem Kanal hat: `Kanal anzeigen`, `Nachrichten senden`, `Links einbetten`, `Externe Emojis verwenden`. Versuche `/notify test` danach.",
+        "FAILED_SEND_NOTIFY": "Fehler beim senden der Benachrichtigung, bitte versuche es erneut",
+        "PLEASE_ALLOW_DM_MESSAGE": "Bitte lasse Direktnachrichten in deinen Privatsphäreeinstellungen zu."
       },
       "notify_send": {
-        "RESPONSE_SPECIFIED": "{emoji} **{name}** is in your daily store!\nRemaining {duration}",
-        "RESPONSE_ALL": "Daily store for **{username}** | Remaining {duration}"
+        "RESPONSE_SPECIFIED": "{emoji} **{name}** ist in deimen täglichen Shop!\nVerbleibend {duration}",
+        "RESPONSE_ALL": "Täglicher Shop für **{username}** | Verbleibend {duration}"
       },
       "notify_channel": {
-        "NAME": "channel",
-        "DESCRIPTION": "Change notification channel.",
+        "NAME": "kanal",
+        "DESCRIPTION": "Ändere den Benachrichtigungskanal",
         "DESCRIBE": {
           "channel": "Select the channel you want to change."
         },
-        "SUCCESS": "Notify channel changed to: **{channel}**"
+        "SUCCESS": "Benachrichtigungskanal zu **{channel}** geändert"
       },
       "bundle": {
-        "NAME": "bundle",
-        "DESCRIPTION": "Inspect a specific bundle",
+        "NAME": "Paket",
+        "DESCRIPTION": "Inspiziere ein bestimmtes Paket",
         "DESCRIBE": {
-          "bundle": "The name of the bundle you want to inspect!"
+          "bundle": "Der Paketnamen zum Inspizieren"
         },
-        "TITLE": "Collection",
-        "DROPDOWN_CHOICE_TITLE": "Select a bundle:",
-        "NOT_FOUND_BUNDLE": "Bundle not found"
+        "TITLE": "Sammlung",
+        "DROPDOWN_CHOICE_TITLE": "Wähle ein Paket:",
+        "NOT_FOUND_BUNDLE": "Paket nicht gefunden"
       },
       "bundles": {
-        "NAME": "bundles",
-        "DESCRIPTION": "View featured bundles in store",
-        "TITLE": "Featured Bundle: {bundle} Collection",
-        "DURATION": "Expires {duration}",
-        "DROPDOWN_CHOICE_TITLE": "Select a bundle:"
+        "NAME": "pakete",
+        "DESCRIPTION": "Vorgestellte Pakete im Shop ansehen",
+        "TITLE": "Vorgestellte Pakete: {bundle} Sammlung",
+        "DURATION": "Läuft {duration} ab",
+        "DROPDOWN_CHOICE_TITLE": "Wähle ein Paket:"
       },
       "debug": {
         "NAME": "debug",
-        "DESCRIPTION": "The command debug for the bot",
+        "DESCRIPTION": "Der Debug-Befehl für den Bot",
         "DESCRIBE": {
-          "bug": "The bug you want to fix.",
+          "bug": "Der Fehler zum beheben",
           "choice": {
-            "skin_price_not_loading": "Skin price not loading",
-            "emoji_price_not_loading": "Emoji not loading",
-            "cache_price_not_loading": "Cache not loading"
+            "skin_price_not_loading": "Skinpreis lädt nicht",
+            "emoji_price_not_loading": "Emoji lädt nicht",
+            "cache_price_not_loading": "Cache lädt nicht"
           }
         },
-        "SUCCESS": "Successfully debugged: **{bug}**"
+        "SUCCESS": "**{bug}** erfolgreich behoben"
       },
       "cookies": {
         "NAME": "cookies",
-        "DESCRIPTION": "Log into your riot account with a browser cookie",
+        "DESCRIPTION": "Melde dich bei deinem Riot Konto mit Browser-Cookies an",
         "DESCRIBE": {
-          "cookie": "Your cookie"
+          "cookie": "Dein Cookie"
         },
-        "SUCCESS": "Successfully logged in",
-        "FAILED": "Invalid cookie"
+        "SUCCESS": "Erfolgreich abgemeldet!",
+        "FAILED": "Unzulässiger Cookie"
       }
     },
     "errors": {
-      "UNKNOW_ERROR": "An unknown error occurred.",
+      "UNKNOW_ERROR": "Ein unbekannter Fehler ist aufgetreten",
       "AUTH": {
-        "INVALID_PASSWORD": "Your username or password may be incorrect!",
-        "RATELIMIT": "Please wait a few minutes and try again.",
-        "COOKIES_EXPIRED": "Cookies has expired, please `/login` again!",
-        "NO_NAME_TAG": "This user hasn't created a name or tagline yet.",
-        "REGION_NOT_FOUND": "An unknown error occurred, please `/login` again",
-        "LOGIN_COOKIE_FAILED": "Login with cookies failed.",
-        "INPUT_2FA_CODE": "Input 2FA code!",
-        "2FA_ENABLE": "You have 2FA enabled!",
-        "2FA_TO_EMAIL": "Riot sent a code to",
-        "2FA_INVALID_CODE": "Code is Invalid. Please `/login` again",
-        "TEMP_LOGIN_NOT_SUPPORT_2FA": "Not supported 2FA, Please use `/login` and use other cmd without username, password."
+        "INVALID_PASSWORD": "Dein Benutzername oder Passwort ist nicht korrekt.",
+        "RATELIMIT": "Bitte warte ein paar Minuten, bevor du es erneut versuchst.",
+        "COOKIES_EXPIRED": "Cookie ist abgelaufen, bitte melde dich erneut mit `/login` an.",
+        "NO_NAME_TAG": "Dieser Benutzer hat noch keinen Namen oder Tagline erstellt.",
+        "REGION_NOT_FOUND": "Ein unbekannter Fehler ist aufgetreten, bitte melde dich erneut mit `/login` an.",
+        "LOGIN_COOKIE_FAILED": "Anmelden mit Cookies fehlgeschlagen.",
+        "INPUT_2FA_CODE": "2FA Code eingeben!",
+        "2FA_ENABLE": "Du hast 2FA aktiviert!",
+        "2FA_TO_EMAIL": "Riot hat einen Code gesentet an: ",
+        "2FA_INVALID_CODE": "Code ist ungültig. Bitte melde dich erneut mit `/login` an.",
+        "TEMP_LOGIN_NOT_SUPPORT_2FA": "2FA nicht unterstützt, bitte melde dich erneut mit `/login` an, nutze aber einen Befehl ohne Benutzername und Passwort."
       },
       "DATABASE": {
-        "NOT_LOGIN": "You're not registered!, please `/login` to register!",
-        "LOGIN_ERROR": "Fail to login, please try again!",
-        "LOGOUT_ERROR": "I can't logout you if you're not registered!",
-        "LOGOUT_EXCEPT": "An error occurred while logging out."
+        "NOT_LOGIN": "Du bist nicht registriert! Bitte nutze `/login` zum Registrieren!",
+        "LOGIN_ERROR": "Anmeldung fehlgeschlagen, bitte versuche es erneut!",
+        "LOGOUT_ERROR": "Ich kann dich nicht abmelden, wenn du nicht angemeldet bist.",
+        "LOGOUT_EXCEPT": "Ein Fehler beim Abmelden ist aufgetreten."
       },
       "API": {
-        "FAILED_ACTIVE": "Failed to activate API",
-        "REQUEST_FAILED": "API Response Failed !"
+        "FAILED_ACTIVE": "Fehler beim aktivieren der API",
+        "REQUEST_FAILED": "API-Antwort fehlgeschlagen"
       },
       "SETUP_EMOJI": {
-        "MISSING_PERM": "I don't have permission to create emojis!",
-        "FAILED_CREATE_EMOJI": "I can't create emojis, please try again"
+        "MISSING_PERM": "Ich besitze keine Berechtigung Emojis zu erstellen!",
+        "FAILED_CREATE_EMOJI": "Ich kann keine Emojis erstellen, bitte versuche es erneut"
       }
     }
   }

--- a/languages/de.json
+++ b/languages/de.json
@@ -1,0 +1,183 @@
+{
+    "translation_by": "Hackante#1482",
+    "commands": {
+      "login": {
+        "NAME": "anmelden",
+        "DESCRIPTION": "Melde dich mit deinem Riot Konto an",
+        "DESCRIBE": {
+          "username": "Benutzername eingeben!",
+          "password": "Passwort eingeben!"
+        },
+        "SUCCESS": "Erfolgreich angemeldet",
+        "FAILED": "Anmelden fehlgeschlagen, bitte versuche es erneut!"
+      },
+      "logout": {
+        "NAME": "abmelden",
+        "DESCRIPTION": "Melde dich ab und lösche deinen Account aus der Datenbank",
+        "SUCCESS": "Erfolgreich abgemeldet!",
+        "FAILED": "Abmelden fehlgeschlagen, bitte versuche es erneut!"
+      },
+      "store": {
+        "NAME": "store",
+        "DESCRIPTION": "Shows your daily store in your accounts",
+        "DESCRIBE": {
+          "username": "Input username! (temporary login)",
+          "password": "Input password! (temporary login)"
+        },
+        "RESPONSE": "Daily store for **{username}** \nResets {duration}"
+      },
+      "point": {
+        "NAME": "point",
+        "DESCRIPTION": "View your remaining Valorant and Radiant Points (VP/RP)",
+        "POINT": "Points"
+      },
+      "mission": {
+        "NAME": "mission",
+        "DESCRIPTION": "View your daily/weekly mission progress",
+        "TITLE": "Mission",
+        "DAILY": "Daily",
+        "WEEKLY": "Weekly",
+        "NEWPLAYER": "New Player",
+        "NO_MISSION": "No missions available",
+        "DAILY_RESET": "Resets {duration}",
+        "REFILLS": "Refills {duration}"
+      },
+      "nightmarket": {
+        "NAME": "nightmarket",
+        "DESCRIPTION": "Show skin offers on the nightmarket",
+        "RESPONSE": "NightMarket for **{username}** | Expires {duration}",
+        "NIGMARKET_HAS_END": "**NightMarket** has been ended"
+      },
+      "battlepass": {
+        "NAME": "battlepass",
+        "DESCRIPTION": "View your battlepass current tier",
+        "RESPONSE": "**Next Reward:** {next}\n**Type:** {type}\n**XP:** {xp}\n**ACT END:** {end}",
+        "TIER": "TIER",
+        "PLAYER_CARD": "Player Card",
+        "SPRAY": "Spray",
+        "BUDDY": "Buddie",
+        "POINT": "Point",
+        "PLAYER_TITLE": "Title",
+        "SKIN": "Skin"
+      },
+      "notify_add": {
+        "NAME": "add",
+        "DESCRIPTION": "Set a notification when a specific skin is available on your store",
+        "DESCRIBE": {
+          "skin": "The name of the skin you want to notify"
+        },
+        "SUCCESS": "Successfully set an notify for the {emoji} **{skin}**",
+        "SKIN_ALREADY_IN_LIST": "{emoji} **{skin}** is already added to your notification list",
+        "NOT_FOUND": "Skin is not found",
+        "REMOVE_NOTIFY": "Remove Notify",
+        "REMOVED_NOTIFY": "**{skin}** has been removed from notify"
+      },
+      "notify_list": {
+        "NAME": "list",
+        "DESCRIPTION": "View skins you have set a notification for.",
+        "TITLE": "Your Notify List",
+        "DONT_HAVE_NOTIFY": "You don't have any notifications",
+        "REMOVE_NOTIFY": "Click button to remove from notify list"
+      },
+      "notify_mode": {
+        "NAME": "mode",
+        "DESCRIPTION": "Change notification mode",
+        "DESCRIBE": {
+          "mode": "The mode you want to change to"
+        },
+        "SUCCESS": "Successfully changed your notification mode to **{mode}**",
+        "TURN_OFF": "Turn off notification mode"
+      },
+      "notify_test": {
+        "NAME": "test",
+        "DESCRIPTION": "Testing notification",
+        "NOTIFY_IS_WORKING": "Notification is working",
+        "NOTIFY_TURN_OFF": "You've not turned on notification mode",
+        "EMPTY_LIST": "Notify list is empty",
+        "BOT_MISSING_PERM": "**I don't have permission to send notifications in this channel!** \nplease check permission the bot can `View channel`, `Send messages`, `Embed links` and `Use external emoji`. in this channel, then try `/notify test`.",
+        "FAILED_SEND_NOTIFY": "Failed to send notification, please try again",
+        "PLEASE_ALLOW_DM_MESSAGE": "Please allow DM message in your privacy settings"
+      },
+      "notify_send": {
+        "RESPONSE_SPECIFIED": "{emoji} **{name}** is in your daily store!\nRemaining {duration}",
+        "RESPONSE_ALL": "Daily store for **{username}** | Remaining {duration}"
+      },
+      "notify_channel": {
+        "NAME": "channel",
+        "DESCRIPTION": "Change notification channel.",
+        "DESCRIBE": {
+          "channel": "Select the channel you want to change."
+        },
+        "SUCCESS": "Notify channel changed to: **{channel}**"
+      },
+      "bundle": {
+        "NAME": "bundle",
+        "DESCRIPTION": "Inspect a specific bundle",
+        "DESCRIBE": {
+          "bundle": "The name of the bundle you want to inspect!"
+        },
+        "TITLE": "Collection",
+        "DROPDOWN_CHOICE_TITLE": "Select a bundle:",
+        "NOT_FOUND_BUNDLE": "Bundle not found"
+      },
+      "bundles": {
+        "NAME": "bundles",
+        "DESCRIPTION": "View featured bundles in store",
+        "TITLE": "Featured Bundle: {bundle} Collection",
+        "DURATION": "Expires {duration}",
+        "DROPDOWN_CHOICE_TITLE": "Select a bundle:"
+      },
+      "debug": {
+        "NAME": "debug",
+        "DESCRIPTION": "The command debug for the bot",
+        "DESCRIBE": {
+          "bug": "The bug you want to fix.",
+          "choice": {
+            "skin_price_not_loading": "Skin price not loading",
+            "emoji_price_not_loading": "Emoji not loading",
+            "cache_price_not_loading": "Cache not loading"
+          }
+        },
+        "SUCCESS": "Successfully debugged: **{bug}**"
+      },
+      "cookies": {
+        "NAME": "cookies",
+        "DESCRIPTION": "Log into your riot account with a browser cookie",
+        "DESCRIBE": {
+          "cookie": "Your cookie"
+        },
+        "SUCCESS": "Successfully logged in",
+        "FAILED": "Invalid cookie"
+      }
+    },
+    "errors": {
+      "UNKNOW_ERROR": "An unknown error occurred.",
+      "AUTH": {
+        "INVALID_PASSWORD": "Your username or password may be incorrect!",
+        "RATELIMIT": "Please wait a few minutes and try again.",
+        "COOKIES_EXPIRED": "Cookies has expired, please `/login` again!",
+        "NO_NAME_TAG": "This user hasn't created a name or tagline yet.",
+        "REGION_NOT_FOUND": "An unknown error occurred, please `/login` again",
+        "LOGIN_COOKIE_FAILED": "Login with cookies failed.",
+        "INPUT_2FA_CODE": "Input 2FA code!",
+        "2FA_ENABLE": "You have 2FA enabled!",
+        "2FA_TO_EMAIL": "Riot sent a code to",
+        "2FA_INVALID_CODE": "Code is Invalid. Please `/login` again",
+        "TEMP_LOGIN_NOT_SUPPORT_2FA": "Not supported 2FA, Please use `/login` and use other cmd without username, password."
+      },
+      "DATABASE": {
+        "NOT_LOGIN": "You're not registered!, please `/login` to register!",
+        "LOGIN_ERROR": "Fail to login, please try again!",
+        "LOGOUT_ERROR": "I can't logout you if you're not registered!",
+        "LOGOUT_EXCEPT": "An error occurred while logging out."
+      },
+      "API": {
+        "FAILED_ACTIVE": "Failed to activate API",
+        "REQUEST_FAILED": "API Response Failed !"
+      },
+      "SETUP_EMOJI": {
+        "MISSING_PERM": "I don't have permission to create emojis!",
+        "FAILED_CREATE_EMOJI": "I can't create emojis, please try again"
+      }
+    }
+  }


### PR DESCRIPTION
## Added
- German Translation

## Comments
`2FA_TO_EMAIL` is not compatible with a good german grammar. It would be better to have a replace string here too (like `{email}`)

And I wasn't sure whether `/login` should be translaed to `/anmelden` already or whether command localizations are not supported yet.

And due to the inconsistency of punctuation marks I am not sure wether I got all right or not