### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,6 @@
-# syntax=docker/dockerfile:1
-
-FROM ubuntu:latest
-RUN apt-get -y update
-RUN apt-get -y install git
-RUN apt-get -y install python3 python3-pip
-
+FROM python:3.8-alpine
 WORKDIR /app
-
 COPY requirements.txt requirements.txt
-
-RUN pip3 install -r requirements.txt
-
+RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
-
-CMD [ "python3", "./bot.py"]
+CMD [ "python", "./bot.py"]


### PR DESCRIPTION
Using the python:3.8-alpine image can significantly reduce the size of the Docker build, as it is a lightweight image.